### PR TITLE
correct example usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For a full list of default environment variables exposed by GitHub see [https://
 
 ```yaml
 steps:
-  - uses: franzdiebold@github-env-vars-action@v1.0.0
+  - uses: franzdiebold/github-env-vars-action@v1.0.0
   - name: Print environment variables
     run: |
       echo "GITHUB_REPOSITORY_OWNER=$GITHUB_REPOSITORY_OWNER"


### PR DESCRIPTION
- `uses: franzdiebold@github-env-vars-action@v1.0.0`

It was throwing the following error:

```
Invalid workflow file
The workflow is not valid. .github/workflows/main.yml (Line: 94, Col: 13): Expected format {org}/{repo}[/path]@ref. Actual 'github-env-vars-action@v1.0.0',Input string was not in a correct format.
```